### PR TITLE
Remove leading newline in detailed report string searches

### DIFF
--- a/percona_playback/full_report/full_report.cc
+++ b/percona_playback/full_report/full_report.cc
@@ -132,37 +132,37 @@ public:
 
     std::string new_query = boost::to_upper_copy(query);
 
-    if (new_query.find("\nSELECT ") != std::string::npos)
+    if (new_query.find("SELECT ") != std::string::npos)
     {
 		nr_select++;
 		nr_select_faster+= faster;
 		nr_select_slower+= slower;
     }
-    else if (new_query.find("\nUPDATE ") != std::string::npos)
+    else if (new_query.find("UPDATE ") != std::string::npos)
     {
 	       	nr_update++;
 		nr_update_faster+= faster;
 		nr_update_slower+= slower;		
     }
-    else if (new_query.find("\nINSERT ") != std::string::npos)
+    else if (new_query.find("INSERT ") != std::string::npos)
     {
 	        nr_insert++;
 		nr_insert_faster+= faster;
 		nr_insert_slower+= slower;
     }
-    else if (new_query.find("\nDELETE ") != std::string::npos)
+    else if (new_query.find("DELETE ") != std::string::npos)
     {
 	        nr_delete++;
 		nr_delete_faster+= faster;
 		nr_delete_slower+= slower;
     }
-    else if (new_query.find("\nREPLACE ") != std::string::npos)
+    else if (new_query.find("REPLACE ") != std::string::npos)
     {
 	        nr_replace++;
 		nr_replace_faster+= faster;
 		nr_replace_slower+= slower;
     }
-    else if (new_query.find("\nDROP ") != std::string::npos)
+    else if (new_query.find("DROP ") != std::string::npos)
     {
  	        nr_drop++;
 		nr_drop_faster+= faster;


### PR DESCRIPTION
The Detailed Report always produces 0s for result counts. This appears to be because of this commit:

```
commit 523cb5d118cdbb0e0cb22564bd1b78fed4e5440c
Author: Frederic Descamps <lefred@percona.com>
Date: Wed Oct 3 11:20:44 2012 +0200

    fix a bug for reporting
```

I feel like there must be something I am missing here, since it seems unlikely that this really would have been broken since 2012, but removing the leading newline in calls like this fix this for me:

```
- if (new_query.find("SELECT ") != std::string::npos)
+ if (new_query.find("\nSELECT ") != std::string::npos)
     {
                nr_select++;
                nr_select_faster+= faster;
                nr_select_slower+= slower;
     }
```

I commented on the bug report here:

https://bugs.launchpad.net/percona-playback/+bug/1181576

But I thought that by submitting a pull request I might be a more timely response, even if it's just to explain why what I have done here is wrong.