### PR TITLE
fix tests in a release build 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Building
 
     $ mkdir build_dir
     $ cd build_dir
-    $ cmake ..
+    $ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
     $ make
 
 Test Suite

--- a/docs/source/installation/compiling_playback.rst
+++ b/docs/source/installation/compiling_playback.rst
@@ -36,7 +36,7 @@ Building
 
   $ mkdir build_dir
   $ cd build_dir
-  $ cmake ..
+  $ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
   $ make
   
 For a debug build run cmake with ``-DCMAKE_BUILD_TYPE=Debug`` and if you would like to compile the plugins as shared libraries use `-DBUILD_SHARED_LIBS:BOOL=ON`.

--- a/docs/source/installation/compiling_playback.rst
+++ b/docs/source/installation/compiling_playback.rst
@@ -21,13 +21,15 @@ In Debian-based distributions, you need to: ::
 
   # apt-get install debhelper autoconf automake libtool \
   gettext intltool libpcap-dev libtbb-dev libmysqlclient-dev \ 
-  libboost-program-options-dev libboost-thread-dev pkg-config cmake
+  libboost-program-options-dev libboost-thread-dev libboost-regex-dev libboost-system-dev \
+  pkg-config cmake
 
 In ``RPM``-based distributions, you need to: ::
 
   # yum install autoconf automake libtool gettext-devel \
   libpcap-devel tbb-devel mysql mysql-devel intltool \
-  boost-program-options-devel boost-thread-devel pkgconfig cmake
+  boost-program-options-devel boost-thread-devel boost-regex-devel boost-system-devel \
+  pkgconfig cmake
 
 Package ``libmysqlclient-dev`` is not strictly needed for compiling, but if you don't have it, you don't get to do the play back part.
 

--- a/percona_playback/test/CMakeLists.txt
+++ b/percona_playback/test/CMakeLists.txt
@@ -14,6 +14,10 @@ list(APPEND tests "thread-pool-sysbench-slow")
 FOREACH(test ${tests})
   add_executable(test-${test} "${test}.cc")
   target_link_libraries(test-${test} libpercona-playback)
-  add_definitions(-DSRCDIR="${PROJECT_SOURCE_DIR}" )
+  add_definitions(-DSRCDIR="${PROJECT_SOURCE_DIR}")
+ 
+  # we need to undefine NDEBUG so that assert don't get removed
+  add_definitions(-UNDEBUG)
+
   add_test(test-${test} ${PROJECT_BINARY_DIR}/percona_playback/test/test-${test})
 ENDFOREACH(test)


### PR DESCRIPTION
The tests crashed because they do important work inside asserts and in a release build they get removed.
In addition update the docs to mention libboost-regex-dev and libboost-system-dev which we forgot to add.