### PR TITLE
add Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: cpp
+
+compiler:
+  - gcc
+
+sudo: false
+
+env:
+  matrix:
+    - TRAVIS_BUILD_TYPE=Debug
+    - TRAVIS_BUILD_TYPE=Release
+
+addons:
+  apt:
+    sources:
+      - kubuntu-backports
+
+    packages:
+      - cmake
+      - libboost-program-options-dev
+      - libboost-regex-dev
+      - libboost-system-dev
+      - libboost-thread-dev
+      - libmysqlclient-dev
+      - libtbb-dev
+
+script: 
+  - mkdir build_dir
+  - cd build_dir
+  - cmake -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE} ..
+  - make
+  - make test
+
+os:
+  - linux


### PR DESCRIPTION
this allows us to automatically run the test suite on every pull request & merge for free.
For an example output take a look at: https://travis-ci.org/undingen/query-playback/builds/197427919
clicking on the `Debug` or `Release` build will show the whole output:
e.g. https://travis-ci.org/undingen/query-playback/jobs/197427920

We used Travis CI very successfully for https://github.com/dropbox/pyston and use it for other dropbox projects too.
I would really like if we could use it for `query-playback` too but in order to use it you will need to activate it at the travis-ci.org website.