### PR TITLE
slowlog: don't interpret 'Time Id Command Argument' as a query

### DIFF
--- a/percona_playback/query_log/query_log.cc
+++ b/percona_playback/query_log/query_log.cc
@@ -124,7 +124,8 @@ void* ParseQueryLogFunc::operator() (void*)  {
     if (p[0] != '#' && startswith(p, "Tcp port: "))
       goto next;
 
-    if (p[0] != '#' && startswith(p, "Time Id Command Argument"))
+    // skip lines like: "Time[ ]+Id[ ]+Command[ ]+Argument"
+    if (p[0] != '#' && startswith(p, "Time"))
       goto next;
 
     /*

--- a/percona_playback/test/crashme-slow.cc
+++ b/percona_playback/test/crashme-slow.cc
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
   struct percona_playback_run_result *r= percona_playback_run(the_percona_playback);
 
   assert(r->err == 0);
-  assert(r->n_queries == 106);
+  assert(r->n_queries == 105);
   assert(r->n_log_entries = 105);
 
   percona_playback_destroy(&the_percona_playback);

--- a/percona_playback/test/sqlbench-transactions-slow.cc
+++ b/percona_playback/test/sqlbench-transactions-slow.cc
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
   struct percona_playback_run_result *r= percona_playback_run(the_percona_playback);
 
   assert(r->err == 0);
-  assert(r->n_queries == 90329);
+  assert(r->n_queries == 90328);
   assert(r->n_log_entries = 90328);
 
   percona_playback_destroy(&the_percona_playback);

--- a/percona_playback/test/sysbench-slow.cc
+++ b/percona_playback/test/sysbench-slow.cc
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
   struct percona_playback_run_result *r= percona_playback_run(the_percona_playback);
 
   assert(r->err == 0);
-  assert(r->n_queries == 10150);
+  assert(r->n_queries == 10149);
   assert(r->n_log_entries = 10149);
 
   percona_playback_destroy(&the_percona_playback);

--- a/percona_playback/test/thread-pool-sysbench-slow.cc
+++ b/percona_playback/test/thread-pool-sysbench-slow.cc
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
   struct percona_playback_run_result *r= percona_playback_run(the_percona_playback);
 
   assert(r->err == 0);
-  assert(r->n_queries == 10150);
+  assert(r->n_queries == 10149);
   assert(r->n_log_entries = 10149);
 
   percona_playback_destroy(&the_percona_playback);


### PR DESCRIPTION
The existing check did not trigger in many cases because the logs contain additional spaces between the words.

e.g.
```
/home/stewart/percona-server/5.5.20/Percona-Server-5.5.20-rel24.1/sql/mysqld, Version: 5.5.20-debug-log (MySQL Community Server (GPL)). started with:
Tcp port: 13000  Unix socket: /home/stewart/percona-server/5.5.20/Percona-Server-5.5.20-rel24.1/mysql-test/var/tmp/mysqld.1.sock
Time                 Id Command    Argument
```