### PR TITLE
Fix compilation with MariaDB; link against SSL libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ add_subdirectory(percona_playback)
 # main percona-playback executable
 include_directories(${PROJECT_SOURCE_DIR})
 add_executable(percona-playback bin/percona_playback.cc)
-target_link_libraries(percona-playback libpercona-playback)
+target_link_libraries(percona-playback libpercona-playback ssl crypto)
 install(TARGETS percona-playback RUNTIME DESTINATION bin LIBRARY DESTINATION lib)
 
 # let one use 'make check' as a synonym for 'make test'

--- a/percona_playback/test/CMakeLists.txt
+++ b/percona_playback/test/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND tests "thread-pool-sysbench-slow")
 
 FOREACH(test ${tests})
   add_executable(test-${test} "${test}.cc")
-  target_link_libraries(test-${test} libpercona-playback)
+  target_link_libraries(test-${test} libpercona-playback ssl crypto)
   add_definitions(-DSRCDIR="${PROJECT_SOURCE_DIR}")
  
   # we need to undefine NDEBUG so that assert don't get removed


### PR DESCRIPTION
When compiling (test targets) in CentOS 6 with MariaDB 10.1 (OpenSSL-devel installed), there is a lot of errors of this type: 
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../lib64/libmysqlclient_r.a(client.c.o): In function `mysql_close_free_options':
(.text+0x3ba): undefined reference to `SSL_CTX_free'

We need to link against crypt and ssl.