### PR TITLE
slowlog: add accurate mode and fix thread leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: cpp
 compiler:
   - gcc
 
+dist: trusty
 sudo: false
 
 env:
@@ -17,6 +18,7 @@ addons:
 
     packages:
       - cmake
+      - libboost-chrono-dev
       - libboost-program-options-dev
       - libboost-regex-dev
       - libboost-system-dev

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ You will need the 'development' packages for all of these (often suffixed by
 The core of Query Playback requires:
 
  * libtbb (Intel Threading Building Blocks)
- * Boost (including boost `program_options`) at least 1.41
+ * Boost >= 1.52
  * libtool
  * gettext
  * intltool
  * pkg-config
- * cmake
+ * cmake >= 2.8.7
 
 The plugin that uses the MySQL client library needs:
  * libmysqlclient (MySQL Client Libraries)

--- a/docs/source/installation/compiling_playback.rst
+++ b/docs/source/installation/compiling_playback.rst
@@ -22,6 +22,7 @@ In Debian-based distributions, you need to: ::
   # apt-get install debhelper autoconf automake libtool \
   gettext intltool libpcap-dev libtbb-dev libmysqlclient-dev \ 
   libboost-program-options-dev libboost-thread-dev libboost-regex-dev libboost-system-dev \
+  libboost-chrono-dev \
   pkg-config cmake
 
 In ``RPM``-based distributions, you need to: ::
@@ -29,6 +30,7 @@ In ``RPM``-based distributions, you need to: ::
   # yum install autoconf automake libtool gettext-devel \
   libpcap-devel tbb-devel mysql mysql-devel intltool \
   boost-program-options-devel boost-thread-devel boost-regex-devel boost-system-devel \
+  libboost-chrono-dev \
   pkgconfig cmake
 
 Package ``libmysqlclient-dev`` is not strictly needed for compiling, but if you don't have it, you don't get to do the play back part.

--- a/percona_playback/CMakeLists.txt
+++ b/percona_playback/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # setup db_thread lib which all plugins depend on
-find_package(Boost COMPONENTS system thread regex program_options REQUIRED)
+find_package(Boost COMPONENTS system thread regex program_options chrono REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
 link_directories(${Boost_LIBRARY_DIR})
 add_library(db_thread STATIC db_thread.cc)

--- a/percona_playback/db_thread.cc
+++ b/percona_playback/db_thread.cc
@@ -1,4 +1,5 @@
 /* BEGIN LICENSE
+ * Copyright (c) 2017 Dropbox, Inc.
  * Copyright (C) 2011-2013 Percona Ireland Ltd.
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2, as published
@@ -37,13 +38,10 @@ void DBThread::run()
 {
   connect_and_init_session();
 
-  while (true)
+  QueryEntryPtr query;
+  do
   {
-    QueryEntryPtr query;
     queries->pop(query);
-
-    if (query->is_shutdown())
-      break;
 
     if (query->is_quit())
     {
@@ -53,7 +51,8 @@ void DBThread::run()
     }
 
     query->execute(this);
-  }
+
+  } while (!query->is_shutdown());
 
   disconnect();
   return;

--- a/percona_playback/general_log/general_log_entry.h
+++ b/percona_playback/general_log/general_log_entry.h
@@ -19,6 +19,7 @@ extern "C"
 class GeneralLogEntry : public QueryEntry
 {
     private:
+      uint64_t thread_id;
       uint64_t rows_sent;
       uint64_t rows_examined;
       double query_time;
@@ -27,7 +28,9 @@ class GeneralLogEntry : public QueryEntry
       std::string query;
     public:
 
-      GeneralLogEntry() : rows_sent(0), rows_examined(0), query_time(0) {}
+      GeneralLogEntry() : thread_id(0), rows_sent(0), rows_examined(0), query_time(0) {}
+
+      virtual uint64_t getThreadId() const { return thread_id; }
 
       inline double getQueryTime() { return query_time; }
 
@@ -37,7 +40,7 @@ class GeneralLogEntry : public QueryEntry
 
       inline void display() { std::cerr << "    " << query << std::endl; }
 
-      inline bool is_quit() { return (query.compare(0, 30, "# administrator command: Quit;") == 0); }
+      inline bool is_quit() const { return (query.compare(0, 30, "# administrator command: Quit;") == 0); }
 
       void execute(DBThread *t);
 };

--- a/percona_playback/general_log/parse_general_log.h
+++ b/percona_playback/general_log/parse_general_log.h
@@ -12,31 +12,26 @@
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_hash_map.h>
 
+#include <percona_playback/plugin.h>
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-class ParseGeneralLog : public tbb::filter {
+class ParseGeneralLog {
     public:
       ParseGeneralLog(FILE *input_file_,
-                unsigned int run_count_,
-                tbb::atomic<uint64_t> *entries_,
-                tbb::atomic<uint64_t> *queries_)
-        : tbb::filter(true),
-          nr_entries(entries_),
-          nr_queries(queries_),
-          input_file(input_file_),
+                unsigned int run_count_)
+        : input_file(input_file_),
           run_count(run_count_),
           next_line(NULL),
           next_len(0)
       {};
 
-      void* operator() (void*);
+      boost::shared_ptr<QueryEntries> getEntries();
 
     private:
-      tbb::atomic<uint64_t> *nr_entries;
-      tbb::atomic<uint64_t> *nr_queries;
       FILE *input_file;
       unsigned int run_count;
       char *next_line;

--- a/percona_playback/plugin.h
+++ b/percona_playback/plugin.h
@@ -1,4 +1,5 @@
 /* BEGIN LICENSE
+ * Copyright (c) 2017 Dropbox, Inc.
  * Copyright (C) 2011-2013 Percona Ireland Ltd.
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2, as published
@@ -113,7 +114,7 @@ class DispatcherPlugin : public plugin
 
   DispatcherPlugin(const std::string &_name) : name(_name) {}
 
-  virtual void dispatch(QueryEntryPtr query_entry)= 0;
+  virtual void dispatch(QueryEntriesPtr query_entries)= 0;
   virtual void finish_all_and_wait()= 0;
 
   virtual void run() {};

--- a/percona_playback/plugin.h
+++ b/percona_playback/plugin.h
@@ -114,7 +114,6 @@ class DispatcherPlugin : public plugin
   DispatcherPlugin(const std::string &_name) : name(_name) {}
 
   virtual void dispatch(QueryEntryPtr query_entry)= 0;
-  virtual bool finish_and_wait(uint64_t thread_id)= 0;
   virtual void finish_all_and_wait()= 0;
 
   virtual void run() {};

--- a/percona_playback/thread_per_connection/thread_per_connection.cc
+++ b/percona_playback/thread_per_connection/thread_per_connection.cc
@@ -31,7 +31,6 @@ public:
 	  DispatcherPlugin(_name) {}
 
   void dispatch(QueryEntryPtr query_entry);
-  bool finish_and_wait(uint64_t thread_id);
   void finish_all_and_wait();
 };
 
@@ -51,30 +50,6 @@ ThreadPerConnectionDispatcher::dispatch(QueryEntryPtr query_entry)
     }
     a->second->queries->push(query_entry);
   }
-}
-
-bool
-ThreadPerConnectionDispatcher::finish_and_wait(uint64_t thread_id)
-{
-  DBThread *db_thread= NULL;
-  {
-    DBExecutorsTable::accessor a;
-    if (executors.find(a, thread_id))
-    {
-      db_thread= a->second;
-      executors.erase(a);
-    }
-  }
-
-  if (!db_thread)
-    return false;
-
-  db_thread->queries->push(QueryEntryPtr(new FinishEntry(thread_id)));
-  db_thread->join();
-
-  delete db_thread;
-
-  return true;
 }
 
 void

--- a/percona_playback/thread_per_connection/thread_per_connection.cc
+++ b/percona_playback/thread_per_connection/thread_per_connection.cc
@@ -1,4 +1,5 @@
 /* BEGIN LICENSE
+ * Copyright (c) 2017 Dropbox, Inc.
  * Copyright (C) 2011-2013 Percona Ireland Ltd.
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2, as published
@@ -16,69 +17,54 @@
 #include "percona_playback/plugin.h"
 #include "percona_playback/db_thread.h"
 
-#include <tbb/concurrent_hash_map.h>
-
-class ThreadPerConnectionDispatcher :
-	public percona_playback::DispatcherPlugin
-{
-  typedef tbb::concurrent_hash_map<uint64_t, DBThread*> DBExecutorsTable;
-  DBExecutorsTable  executors;
-  void db_thread_func(DBThread *thread);
-  void start_thread(DBThread *thread);
-
-public:
-  ThreadPerConnectionDispatcher(std::string _name) :
-	  DispatcherPlugin(_name) {}
-
-  void dispatch(QueryEntryPtr query_entry);
-  void finish_all_and_wait();
-};
+#include <boost/unordered_map.hpp>
 
 extern percona_playback::DBClientPlugin *g_dbclient_plugin;
 
-void
-ThreadPerConnectionDispatcher::dispatch(QueryEntryPtr query_entry)
+class ThreadPerConnectionDispatcher :
+        public percona_playback::DispatcherPlugin
 {
-  uint64_t thread_id= query_entry->getThreadId();
-  {
-    DBExecutorsTable::accessor a;
-    if (executors.insert(a, thread_id))
-    {
-      DBThread *db_thread= g_dbclient_plugin->create(thread_id);
-      a->second= db_thread;
+  typedef boost::unordered_map<uint64_t, DBThread*> DBExecutorsTable;
+  DBExecutorsTable  executors;
+
+public:
+  ThreadPerConnectionDispatcher(std::string _name) :
+          DispatcherPlugin(_name) {}
+
+  void dispatch(QueryEntriesPtr query_entries);
+  void finish_all_and_wait();
+};
+
+void
+ThreadPerConnectionDispatcher::dispatch(QueryEntriesPtr query_entries)
+{
+  // automatically close threads after last request
+  query_entries->setShutdownOnLastQueryOfConn();
+
+  while (QueryEntryPtr query_entry = query_entries->popEntry()) {
+    uint64_t thread_id = query_entry->getThreadId();
+    DBThread*& db_thread = executors[thread_id];
+    if (!db_thread) {
+      db_thread = g_dbclient_plugin->create(thread_id);
       db_thread->start_thread();
     }
-    a->second->queries->push(query_entry);
+    db_thread->queries->push(query_entry);
   }
 }
 
 void
 ThreadPerConnectionDispatcher::finish_all_and_wait()
 {
-  QueryEntryPtr shutdown_command(new FinishEntry(0));
-
-  while(executors.size())
-  {
-    uint64_t thread_id;
-    DBThread *t;
-    {
-      DBExecutorsTable::const_iterator iter= executors.begin();
-      thread_id= (*iter).first;
-      t= (*iter).second;
-    }
-    executors.erase(thread_id);
-
-    t->queries->push(shutdown_command);
-    t->join();
-
-    delete t;
+  for (DBExecutorsTable::iterator it = executors.begin(), end = executors.end(); it != end; ++it) {
+    it->second->join();
+    delete it->second;
   }
 }
 
 static void init_plugin(percona_playback::PluginRegistry &r)
 {
   r.add("thread-per-connection",
-	new ThreadPerConnectionDispatcher("thread-per-connection"));
+        new ThreadPerConnectionDispatcher("thread-per-connection"));
 }
 
 PERCONA_PLAYBACK_PLUGIN(init_plugin);

--- a/percona_playback/thread_pool/thread_pool.cc
+++ b/percona_playback/thread_pool/thread_pool.cc
@@ -44,7 +44,6 @@ public:
 	  options("Threads-pool Options") {}
 
   virtual void dispatch(QueryEntryPtr query_entry);
-  virtual bool finish_and_wait(uint64_t) { return true; }
   virtual void finish_all_and_wait();
   virtual void run();
 

--- a/percona_playback/thread_pool/thread_pool.cc
+++ b/percona_playback/thread_pool/thread_pool.cc
@@ -1,4 +1,5 @@
 /* BEGIN LICENSE
+ * Copyright (c) 2017 Dropbox, Inc.
  * Copyright (C) 2011-2013 Percona Ireland Ltd.
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2, as published
@@ -21,7 +22,6 @@
 #include <boost/crc.hpp>
 #include <vector>
 
-#include <tbb/concurrent_hash_map.h>
 #include <stdio.h>
 
 extern percona_playback::DBClientPlugin *g_dbclient_plugin;
@@ -43,7 +43,7 @@ public:
 	  threads_count(0),
 	  options("Threads-pool Options") {}
 
-  virtual void dispatch(QueryEntryPtr query_entry);
+  virtual void dispatch(QueryEntriesPtr query_entries);
   virtual void finish_all_and_wait();
   virtual void run();
 
@@ -62,24 +62,35 @@ void ThreadPoolDispatcher::run()
   }
 }
 
-void ThreadPoolDispatcher::dispatch(QueryEntryPtr query_entry)
+void ThreadPoolDispatcher::dispatch(QueryEntriesPtr query_entries)
 {
-  /*
-    Each worker has its own queue. For some types of input plugins
-    it is important to execute query entries with the same thread id
-    by the same worker. That is why we choose worker by simple hash from
-    thread id.
-  */
-  uint64_t thread_id= query_entry->getThreadId();
-  boost::crc_32_type crc;
-  crc.process_bytes(&thread_id, sizeof(thread_id));
-  uint32_t worker_index = crc.checksum() % workers.size();
-  workers[worker_index]->queries->push(query_entry);
+  while (QueryEntryPtr entry = query_entries->popEntry()) {
+    /*
+     Each worker has its own queue. For some types of input plugins
+     it is important to execute query entries with the same thread id
+     by the same worker. That is why we choose worker by simple hash from
+     thread id.
+    */
+    uint64_t thread_id= entry->getThreadId();
+    boost::crc_32_type crc;
+    crc.process_bytes(&thread_id, sizeof(thread_id));
+    uint32_t worker_index = crc.checksum() % workers.size();
+    workers[worker_index]->queries->push(entry);
+  }
 }
+
+class FinishEntry : public QueryEntry
+{
+public:
+  FinishEntry() : QueryEntry (true) {}
+  virtual bool is_quit() const { return false; }
+  virtual uint64_t getThreadId() const { return 0; }
+  virtual void execute(DBThread *) {}
+};
 
 void ThreadPoolDispatcher::finish_all_and_wait()
 {
-  QueryEntryPtr shutdown_command(new FinishEntry(0));
+  QueryEntryPtr shutdown_command(new FinishEntry);
   for (Workers::iterator i = workers.begin(), end = workers.end(); i != end; ++i)
     (*i)->queries->push(shutdown_command);
   for (Workers::iterator i = workers.begin(), end = workers.end(); i != end; ++i)


### PR DESCRIPTION
This patch adds an "accurate" replay mode.
In this mode we try to preserve the relative start time of every query as best as possible - we will not replay as fast as possible but instead preserve the pauses between queries.
This is useful when one does not want to test peak throughput but instead the real load the database had.

Unfurtunately this mode requires us to preprocess the slowlog and keep the queries in memory.
I reduced the memory consumption by read only mmaping the slow query log (so that the OS can page it/out as required)
and keeping only minimal data about every query in memory and reading most data lazily from the memory mapped file.

The query start time is calculated by subtracting the "Query_time" from the end timestamp we find inside the "# Time:" metadata.
We then order all queries based on the timstamp (and for queries from the same connection we preserve the order in which they appear inside the slowlog).
After that we calculate the difference between the current time and the one of the first recorded query and use it as an offset for all further queries.
Before executing any query we wait until the recorded timestamp rebased by the offset is reached.

In addition this patch makes sure that every connection/thread gets shutdown when the last query of the connection got executed (in thread-per-connection mode).
Enabling percona servers "slow_query_log_timestamp_precision" helps making the replay more accurate.