### PR TITLE
workaround boost 1.53 bug & fix CentOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You will need the 'development' packages for all of these (often suffixed by
 The core of Query Playback requires:
 
  * libtbb (Intel Threading Building Blocks)
- * Boost >= 1.52
+ * Boost >= 1.53
  * pkg-config
  * cmake >= 2.8.7
 

--- a/percona_playback/CMakeLists.txt
+++ b/percona_playback/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # setup db_thread lib which all plugins depend on
-find_package(Boost COMPONENTS system thread regex program_options chrono REQUIRED)
+find_package(Boost 1.53.0 COMPONENTS system thread regex program_options chrono REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
 link_directories(${Boost_LIBRARY_DIR})
 add_library(db_thread STATIC db_thread.cc)

--- a/percona_playback/mysql_client/CMakeLists.txt
+++ b/percona_playback/mysql_client/CMakeLists.txt
@@ -24,10 +24,13 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/percona_playback")
 include(plugin)
 
-find_path(MYSQL_INC "mysql/mysql.h")
-include_directories("${MYSQL_INC}/mysql")
+find_file(MYSQL_INC "mysql.h" PATH_SUFFIXES "mysql")
+get_filename_component(MYSQL_INC ${MYSQL_INC} PATH)
+include_directories(${MYSQL_INC})
+
+find_library(MYSQL_LIB "mysqlclient_r" PATH_SUFFIXES "mysql")
 
 add_library(mysql_client mysql_client.cc)
-target_link_libraries(mysql_client mysqlclient_r crypto ssl)
+target_link_libraries(mysql_client ${MYSQL_LIB} crypto ssl)
 
 setup_plugin("mysql_client")

--- a/percona_playback/query_log/query_log.h
+++ b/percona_playback/query_log/query_log.h
@@ -58,10 +58,7 @@ public:
 
   virtual void execute(DBThread *t);
 
-  virtual bool is_quit() const
-  {
-    return data.find("\n# administrator command: Quit;") != boost::string_ref::npos;
-  }
+  virtual bool is_quit() const;
 
   uint64_t parseThreadId() const;
   uint64_t parseRowsSent() const;


### PR DESCRIPTION
- `boost::string_ref::find(string::ref)` is broken in 1.53
https://svn.boost.org/trac/boost/ticket/8067
- search for `libmysqlclient_r.so` in `mysql` directory
CentOS puts the lib into a mysql subdirectory: `/usr/lib64/mysql/`


fixes #27