### PR TITLE
slowlog: improve accurracy of replay

### DIFF
--- a/percona_playback/query_log/query_log.cc
+++ b/percona_playback/query_log/query_log.cc
@@ -187,8 +187,13 @@ boost::shared_ptr<QueryLogEntries> getEntries(boost::string_ref data)  {
     }
   }
 
-  if (!g_disable_sorting || g_accurate_mode)
+  std::cerr << _(" Finished reading log entries") << std::endl;
+  if (!g_disable_sorting || g_accurate_mode) {
+    std::cerr << _(" Start sorting log entries") << std::endl;
     std::stable_sort(entries->entries.begin(), entries->entries.end());
+    std::cerr << _(" Finished sorting log entries") << std::endl;
+  }
+  std::cerr << _(" Finished preprocessing - starting playback...") << std::endl;
 
   return entries;
 }

--- a/percona_playback/query_log/query_log.h
+++ b/percona_playback/query_log/query_log.h
@@ -52,11 +52,13 @@ public:
   boost::string_ref data; // query including metadata
   mutable uint64_t thread_id; // we cache the thread id
   TimePoint start_time;
+  mutable uint64_t innodb_trx_id;
 
 public:
   QueryLogData(boost::string_ref data, TimePoint end_time)
     : data(data), thread_id(0),
-      start_time(end_time - boost::chrono::microseconds((long)(parseQueryTime() * boost::micro::den))) {
+      start_time(end_time - boost::chrono::microseconds((long)(parseQueryTime() * boost::micro::den))),
+      innodb_trx_id(-1) {
   }
 
   void execute(DBThread *t);
@@ -66,6 +68,7 @@ public:
   uint64_t parseRowsSent() const;
   uint64_t parseRowsExamined() const;
   double parseQueryTime() const;
+  uint64_t parseInnoDBTrxId() const;
 
   TimePoint getStartTime() const { return start_time; }
 

--- a/percona_playback/query_log/query_log.h
+++ b/percona_playback/query_log/query_log.h
@@ -51,7 +51,7 @@ public:
 
   boost::string_ref data; // query including metadata
   mutable uint64_t thread_id; // we cache the thread id
-  TimePoint start_time; // only valid if g_preserve_query_starttime is enabled
+  TimePoint start_time;
 
 public:
   QueryLogData(boost::string_ref data, TimePoint end_time)
@@ -67,8 +67,7 @@ public:
   uint64_t parseRowsExamined() const;
   double parseQueryTime() const;
 
-  // only valid if g_preserve_query_starttime is enabled
-  TimePoint getStartTime() const;
+  TimePoint getStartTime() const { return start_time; }
 
   std::string getQuery(bool remove_timestamp);
 


### PR DESCRIPTION
Running several smaller replays showed that with the following changes the accuracy can be improved: 
- use the InnoDB transaction ID as sort criteria (if available)
- sort queries also in non accurate mode

I will run tomorrow further tests and hope to improve it further and will verify that I don't see regressions on large captures.