### PR TITLE
slowlog: fix accuracy

### DIFF
--- a/percona_playback/query_log/query_log.cc
+++ b/percona_playback/query_log/query_log.cc
@@ -57,7 +57,6 @@ static bool g_run_set_timestamp;
 static bool g_preserve_query_time;
 static bool g_accurate_mode;
 static bool g_disable_sorting;
-static bool g_use_innodb_trx_id;
 
 static boost::atomic<long long> g_max_behind_ns;
 
@@ -202,14 +201,6 @@ bool QueryLogData::operator <(const QueryLogData& right) const {
   // for same connections we make sure that the follow the order in the query log
   if (parseThreadId() == right.parseThreadId())
     return data.data() < right.data.data();
-
-  if (g_use_innodb_trx_id) {
-    uint64_t id_left = parseInnoDBTrxId();
-    uint64_t id_right = right.parseInnoDBTrxId();
-    if (id_left && id_right)
-      return id_left < id_right;
-  }
-
   return getStartTime() < right.getStartTime();
 }
 
@@ -344,19 +335,6 @@ double QueryLogData::parseQueryTime() const {
   return 0.0;
 }
 
-uint64_t QueryLogData::parseInnoDBTrxId() const {
-  // use cached innodb trx id
-  if (innodb_trx_id != -1)
-    return innodb_trx_id;
-
-  innodb_trx_id = 0;
-  size_t location= find(data, "InnoDB_trx_id: ");
-  if (location != std::string::npos) {
-    innodb_trx_id = strtoull(&data[location + strlen("InnoDB_trx_id: ")], NULL, 16 /* hex number */);
-  }
-  return innodb_trx_id;
-}
-
 extern percona_playback::DBClientPlugin *g_dbclient_plugin;
 
 static void LogReaderThread(boost::string_ref data, struct percona_playback_run_result *r)
@@ -433,10 +411,6 @@ public:
        _("Disables the sorting of queries based on time (and InnoDB TRX ID). "
          "Instead replays queries in the order they appear in the log. "
          "Ignored in accurate mode which always does the sorting."))
-      ("query-log-use-innodb-trx-id",
-       po::value<bool>(&g_use_innodb_trx_id)->
-        default_value(true),
-       _("Uses the InnoDB Transaction Id to sort queries for improved accuracy. (Default: on)"))
       ;
 
     return &options;

--- a/percona_playback/query_log/query_log.h
+++ b/percona_playback/query_log/query_log.h
@@ -68,6 +68,7 @@ public:
   double parseQueryTime() const;
 
   TimePoint getStartTime() const { return start_time; }
+  void setStartTime(TimePoint tp) { start_time = tp; }
 
   std::string getQuery(bool remove_timestamp);
 

--- a/percona_playback/query_log/query_log.h
+++ b/percona_playback/query_log/query_log.h
@@ -52,13 +52,11 @@ public:
   boost::string_ref data; // query including metadata
   mutable uint64_t thread_id; // we cache the thread id
   TimePoint start_time;
-  mutable uint64_t innodb_trx_id;
 
 public:
   QueryLogData(boost::string_ref data, TimePoint end_time)
     : data(data), thread_id(0),
-      start_time(end_time - boost::chrono::microseconds((long)(parseQueryTime() * boost::micro::den))),
-      innodb_trx_id(-1) {
+      start_time(end_time - boost::chrono::microseconds((long)(parseQueryTime() * boost::micro::den))) {
   }
 
   void execute(DBThread *t);
@@ -68,7 +66,6 @@ public:
   uint64_t parseRowsSent() const;
   uint64_t parseRowsExamined() const;
   double parseQueryTime() const;
-  uint64_t parseInnoDBTrxId() const;
 
   TimePoint getStartTime() const { return start_time; }
 


### PR DESCRIPTION
This fixes a bad bug I introduced which could result in queries getting executed in the wrong order.
With this I'm seeing very low / no errors anymore when replaying. It also reverts the InnoDB transaction id change because it does not help at the moment but introduces further inaccuracies. I guess before I fixed the bug I just good lucky and the using the trx ids helped but now it's not needed anymore / makes things worse.

Bug fix:
we have to adjust the start time so that inside every connection the start times of each query is the same as the previous one or later but never sooner than the previous query.
This could happen because of inaccuracies in the slowlog and would result in the
execution of queries in the wrong order because of the sorting we do.




