### PR TITLE
Performance and reliability improvements to thread-per-connection

### DIFF
--- a/percona_playback/db_thread.cc
+++ b/percona_playback/db_thread.cc
@@ -36,7 +36,10 @@ void DBThread::init_session()
 
 void DBThread::run()
 {
-  connect_and_init_session();
+  /* Do not connect to the database yet... we might have to sleep
+     before running queries, lets not hog a connection if we don't have
+     to. execute() will now connect for us if we are not connected */
+  // connect_and_init_session();
 
   QueryEntryPtr query;
   do
@@ -58,7 +61,7 @@ void DBThread::run()
   return;
 }
 
-void 
+void
 DBThread::start_thread()
 {
   assert(!thread.joinable());

--- a/percona_playback/db_thread.h
+++ b/percona_playback/db_thread.h
@@ -54,12 +54,12 @@ public:
 
   virtual ~DBThread() {}
 
-  bool join()
+  bool nonblocking_join()
   {
       return thread.try_join_for(boost::chrono::milliseconds(1));
   }
 
-  void blocking_join()
+  void join()
   {
       thread.join();
   }

--- a/percona_playback/db_thread.h
+++ b/percona_playback/db_thread.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include "percona_playback/visibility.h"
+#include <boost/chrono.hpp>
 #include <boost/thread.hpp>
 #include <boost/shared_ptr.hpp>
 #include <tbb/concurrent_queue.h>
@@ -53,9 +54,14 @@ public:
 
   virtual ~DBThread() {}
 
-  void join()
+  bool join()
   {
-    thread.join();
+      return thread.try_join_for(boost::chrono::milliseconds(1));
+  }
+
+  void blocking_join()
+  {
+      thread.join();
   }
 
   bool connect_and_init_session()

--- a/percona_playback/mysql_client/mysql_client.h
+++ b/percona_playback/mysql_client/mysql_client.h
@@ -26,6 +26,8 @@ class MySQLDBThread : public DBThread
   MYSQL handle;
   MySQLOptions *options;
   int num_connect_errors;
+  bool have_connected;
+
 
  public:
   MySQLDBThread(uint64_t _thread_id, MySQLOptions *opt) :

--- a/percona_playback/thread_per_connection/thread_per_connection.cc
+++ b/percona_playback/thread_per_connection/thread_per_connection.cc
@@ -26,6 +26,7 @@ class ThreadPerConnectionDispatcher :
 {
   typedef boost::unordered_map<uint64_t, DBThread*> DBExecutorsTable;
   DBExecutorsTable  executors;
+  int num_running;
 
 public:
   ThreadPerConnectionDispatcher(std::string _name) :
@@ -33,11 +34,15 @@ public:
 
   void dispatch(QueryEntriesPtr query_entries);
   void finish_all_and_wait();
+  void finish_some_and_go();
 };
 
 void
 ThreadPerConnectionDispatcher::dispatch(QueryEntriesPtr query_entries)
 {
+  // Keep track of how many threads we have started
+  num_running = 0;
+
   // automatically close threads after last request
   query_entries->setShutdownOnLastQueryOfConn();
 
@@ -45,16 +50,63 @@ ThreadPerConnectionDispatcher::dispatch(QueryEntriesPtr query_entries)
     uint64_t thread_id = query_entry->getThreadId();
     DBThread*& db_thread = executors[thread_id];
     if (!db_thread) {
+
+      /* Under high load, it's possible to have too many threads
+         running for the system. 10000 threads seems to be a good value
+         to where we do not exhaust system resources, and maintain high
+         throughput. Keeping the queue-depth at a high number is
+         important to not get stuck waiting on long queries to finish.
+
+         NOTE: It is technically possible to get stuck here forever, if
+         there are actually 10000 threads that can't finish because at
+         the time there are actually 10000 open transactions/connections
+         that will now never get their shutdown on last query...
+
+         But on workloads in the 2000-5000+ QPS range, this works
+         much better. */
+
+      // TODO: Make this 10000 an option &| do something if we seem stuck
+      while ( num_running > 10000 ) {
+        /* Allow some time for some threads to maybe finish */
+        usleep(100000);
+        /* Try to clean up threads that are done and
+           bring the thread count down to within sane limits */
+        ThreadPerConnectionDispatcher::finish_some_and_go();
+      }
+
       db_thread = g_dbclient_plugin->create(thread_id);
+      num_running += 1;
       db_thread->start_thread();
     }
     db_thread->queries->push(query_entry);
+
+  }
+}
+
+void
+ThreadPerConnectionDispatcher::finish_some_and_go()
+{
+  /* this is very similar to finish_all_and_wait(), except nonblocking_join()
+     is now a try-for-join that only tries for 1ms. The idea is that we join up
+     whatever threads are done and clean them out of the DBExecutorsTable
+     quickly so we can get back to making new threads */
+  for (DBExecutorsTable::iterator it = executors.begin(), end = executors.end(); it != end; ) {
+    if (it->second && it->second->nonblocking_join()) {
+      // FYI, erase(it) returns iterator to next element, so don't need to increment.
+      it = executors.erase(it);
+      num_running -= 1;
+    } else {
+      it++;
+    }
   }
 }
 
 void
 ThreadPerConnectionDispatcher::finish_all_and_wait()
 {
+  /* This is the final finish_all, and we DO want joins to actually join
+     regardless of how long it takes to finish. Therefore, we use
+     join() to block forever until the thread is done. */
   for (DBExecutorsTable::iterator it = executors.begin(), end = executors.end(); it != end; ++it) {
     it->second->join();
     delete it->second;


### PR DESCRIPTION
When playing back long captures and/or captures from high-throughput systems, playback was having some trouble. The thread-pool is insufficient for attempting to reproduce max-connections or system resource exhaustion because it forces the entire playback through a fixed connection pool. Therefore, our requirements were to preserve query time as close as possible, with one thread per connection, as close to reality as possible.

A number of problems were encountered when attempting to do this. The problems consisted of mainly 2 topics: Resource exhaustion on the load generating server ( the one using percona playback ), and inconsistency when MySQL started throwing "Too many connections" or "MySQL has gone away" errors.

In reality, when a MySQL server is struggling to keep up with unbounded inbound workload, clients retry their transactions/connections until they work. We needed to simulate this behavior to make sure the queries actually got ran, but we couldn't because of the aforementioned resource exhaustion ( eg, Boost Thread Resource constraints )

To solve these problems we made some modifications to playback that we would like to give back. We will potentially continue to make improvements when necessary, but we are at an acceptable functionality level now and therefore making this pull request.

To emulate real client behavior, we make the mysql client retry connections ( with increasingly longer back-off sleeping ) specifically when "Too Many Connections" creeps up. But what we found was that when new db threads got created, they immediately connected to the database, whether or not the query log dispatcher was going to sleep or not to sync up the playback timing. Therefore, we removed the immediate connection to the database, and postponed it to when the queries actually needed to execute. This helps minimize the initial blast of "too many connections" as well. In doing so, we also have to track the state of whether or not we have connected, to protect us from mysql_close being called on a never-initialized db_handle.

Solving the thread resource issues on the load-generating machine required really taking a look at what kind of thread management was being done. It appears that the creation of threads was unbounded and pretty much went as fast as the log parser could go, regardless of how fast the database was responding. Especially in circumstances where "too many connections" was reached, this caused the query log dispatcher to get quite a far bit ahead and eventually exhausted the thread resource limits of boost ( i'm assuming. ) Theoretically, on workloads that use a connection pool in reality, this might not have been as much of a problem - but on workloads that do NOT use a connection pool, this can be disastrous to percona-playback. The solution for us was to create a bound on the number of db_threads, 10000 seems to be a fair tradeoff between stability and throughput. We keep track of how many we create, and when we exceed 10000 total threads, go through a "nonblocking" join process of joining any threads which are done, removing them from the DBExecutorsTable, before carrying on to make more. In this way, the query log dispatcher can get "ahead" of the db_threads, but not so far ahead as to exhaust our resources.

After a number of iterations, we have been able to sustain 4+ hours of full-load playback running upwards of 40M queries, with QPS in the upper 2k range. Gzipped full slow query logs (30+ GB Uncompressed ) were piped into percona-playback with the options --query-log-preserve-query-time --query-log-accurate-mode --mysql-test-connect=off --queue-depth 10000 to attain these results.

It is important to note that having a queue-depth of 1 will cause the entire playback to hang the second it attempts to push a query into a db_thread which is busy running a long running query. Therefore, to get sufficient replay value on a workload that contains occasional slow queries, we need to ensure queue-depth is sufficiently large to not restrict the dispatcher from doing its job. Workloads that do NOT have occasional slow queries will NOT suffer from this effect.