### PR TITLE
Adapts name of the mysql client library

### DIFF
--- a/percona_playback/mysql_client/CMakeLists.txt
+++ b/percona_playback/mysql_client/CMakeLists.txt
@@ -28,7 +28,7 @@ find_file(MYSQL_INC "mysql.h" PATH_SUFFIXES "mysql")
 get_filename_component(MYSQL_INC ${MYSQL_INC} PATH)
 include_directories(${MYSQL_INC})
 
-find_library(MYSQL_LIB "mysqlclient_r" PATH_SUFFIXES "mysql")
+find_library(MYSQL_LIB "mysqlclient" PATH_SUFFIXES "mysql")
 
 add_library(mysql_client mysql_client.cc)
 target_link_libraries(mysql_client ${MYSQL_LIB} crypto ssl)


### PR DESCRIPTION
Prior to MySQL 5.5 there used to be two versions of libmysqlclient. The version with the _r suffix was threadsafe, the one without was not. Since the release of MySQL 5.5, both versions are threadsafe and the _r version is only a symlink to libmysqlclient.so.  

I quote the [MySQL 5.5 Release Notes](https://dev.mysql.com/doc/relnotes/mysql/5.5/en/news-5-5-0.html) below:

> The libmysqlclient client library is now built as a thread-safe library. The libmysqlclient_r client library is still present for compatibility, but is just a symbolic link to libmysqlclient.

In Ubuntu (and probably other Debian based systems), the libmysqlclient_r.so was removed and so was the symlink. Thus the compilation fails with the following error: 

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
MYSQL_LIB
    linked by target "mysql_client" in directory /home/sproell/git/query-playback/percona_playback/mysql_client
 
-- Configuring incomplete, errors occurred!
See also "/home/sproell/git/query-playback/build_dir/CMakeFiles/CMakeOutput.log".
See also "/home/sproell/git/query-playback/build_dir/CMakeFiles/CMakeError.log".
```
As a fix for this issue, I recommend replacing ` libmysqlclient_r` with ` libmysqlclient` to be compatible with more recent releases.
